### PR TITLE
Fixing node-sass required version

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "axios": "^0.16.1",
     "lodash": "^4.17.4",
-    "node-sass": "^4.5.2",
+    "node-sass": "4.5.2",
     "pug": "^2.0.0-rc.1",
     "sass-loader": "^6.0.5",
     "vee-validate": "^2.0.0-rc.3",


### PR DESCRIPTION
This was necessary to make installation replicable in my environment